### PR TITLE
feat: add go-tdlib telegram client

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -2,6 +2,9 @@ module tg2sip
 
 go 1.24.3
 
-require gopkg.in/ini.v1 v1.67.0
+require (
+	github.com/zelenin/go-tdlib v0.7.6
+	gopkg.in/ini.v1 v1.67.0
+)
 
 require github.com/stretchr/testify v1.10.0 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -4,6 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/zelenin/go-tdlib v0.7.6 h1:ts5iumjADPH669/Gjlyr9dkygkeRa4O5lGNTNv+5azI=
+github.com/zelenin/go-tdlib v0.7.6/go.mod h1:yqNbNZenZtXPKgf9hDuyZbsRz7qlxOxdfKOc+sAxxIE=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go/main.go
+++ b/go/main.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"log"
+	"path/filepath"
 	"time"
 
+	client "github.com/zelenin/go-tdlib/client"
 	"gopkg.in/ini.v1"
 )
 
@@ -12,8 +16,56 @@ func startSIP() error {
 	return nil
 }
 
-func startTG() error {
-	log.Println("starting Telegram client (stub)")
+var tgClient *client.Client
+
+func startTG(cfg *ini.File) error {
+	log.Println("starting Telegram client")
+	sec := cfg.Section("telegram")
+
+	apiID, err := sec.Key("api_id").Int()
+	if err != nil {
+		return fmt.Errorf("telegram.api_id: %w", err)
+	}
+	apiHash := sec.Key("api_hash").String()
+	if apiHash == "" {
+		return fmt.Errorf("telegram.api_hash is empty")
+	}
+
+	dataDir := sec.Key("database_folder").String()
+	if dataDir == "" {
+		dataDir = filepath.Join(".tdlib")
+	}
+
+	params := &client.SetTdlibParametersRequest{
+		UseTestDc:              false,
+		DatabaseDirectory:      filepath.Join(dataDir, "database"),
+		FilesDirectory:         filepath.Join(dataDir, "files"),
+		UseFileDatabase:        true,
+		UseChatInfoDatabase:    true,
+		UseMessageDatabase:     true,
+		UseSecretChats:         false,
+		ApiId:                  int32(apiID),
+		ApiHash:                apiHash,
+		SystemLanguageCode:     sec.Key("system_language_code").MustString("en"),
+		DeviceModel:            sec.Key("device_model").MustString("tg2sip"),
+		SystemVersion:          sec.Key("system_version").MustString("linux"),
+		ApplicationVersion:     sec.Key("application_version").MustString("0.1"),
+		EnableStorageOptimizer: true,
+	}
+
+	authorizer := client.ClientAuthorizer(params)
+	go client.CliInteractor(authorizer)
+
+	tgClient, err = client.NewClient(authorizer)
+	if err != nil {
+		return fmt.Errorf("tdlib client: %w", err)
+	}
+
+	me, err := tgClient.GetMe(context.Background())
+	if err != nil {
+		return fmt.Errorf("get me: %w", err)
+	}
+	log.Printf("telegram authorized as %s %s (@%s)", me.FirstName, me.LastName, me.Username)
 	return nil
 }
 
@@ -34,7 +86,7 @@ func main() {
 	if err := startSIP(); err != nil {
 		log.Fatalf("failed to start SIP client: %v", err)
 	}
-	if err := startTG(); err != nil {
+	if err := startTG(cfg); err != nil {
 		log.Fatalf("failed to start Telegram client: %v", err)
 	}
 	if err := startGateway(); err != nil {


### PR DESCRIPTION
## Summary
- integrate go-tdlib and initialize Telegram client from config

## Testing
- `go build ./...` *(fails: fatal error: td/telegram/td_json_client.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a253bef0108326890d336f92dc9ef4