### PR TITLE
Implement SIP call context and helper methods

### DIFF
--- a/go/sipclient.go
+++ b/go/sipclient.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+
+	gosip "github.com/ghettovoice/gosip"
+)
+
+// SIPClient provides helper methods to interact with the SIP server.
+type SIPClient struct {
+	srv gosip.Server
+}
+
+// NewSIPClient creates a new SIPClient.
+func NewSIPClient(srv gosip.Server) *SIPClient {
+	return &SIPClient{srv: srv}
+}
+
+// Dial starts a new outbound call.
+func (c *SIPClient) Dial(ctx context.Context, from, to string) error {
+	coreLog.Infof("SIP Dial from %s to %s", from, to)
+	return nil
+}
+
+// Answer answers an incoming call identified by callID.
+func (c *SIPClient) Answer(ctx context.Context, callID string) error {
+	coreLog.Infof("SIP Answer call %s", callID)
+	return nil
+}
+
+// Hangup terminates a call identified by callID.
+func (c *SIPClient) Hangup(ctx context.Context, callID string) error {
+	coreLog.Infof("SIP Hangup call %s", callID)
+	return nil
+}
+
+// DialDtmf sends DTMF digits during a call.
+func (c *SIPClient) DialDtmf(ctx context.Context, callID, digits string) error {
+	coreLog.Infof("SIP DTMF on %s: %s", callID, digits)
+	return nil
+}
+
+// BridgeAudio connects audio between two calls.
+func (c *SIPClient) BridgeAudio(ctx context.Context, srcID, dstID string) error {
+	coreLog.Infof("SIP BridgeAudio %s <-> %s", srcID, dstID)
+	return nil
+}


### PR DESCRIPTION
## Summary
- add gateway event loop handling SIP call state and media events
- introduce call context creation on INVITE
- provide SIP helper with Dial/Answer/Hangup/DTMF/Bridge stubs

## Testing
- `go test ./...` *(fails: td_json_client.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a2608a7b988326b1722a9f52cb4963