### PR TITLE
Add Docker setup for tg2sip-go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.22-bookworm AS build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libtdjson-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY go go
+
+RUN cd go && go build -o tg2sip-go
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libtdjson && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=build /app/go/tg2sip-go /app/go/tg2sip-go
+COPY settings.ini /app/settings.ini
+
+WORKDIR /app/go
+
+EXPOSE 5060/udp
+
+CMD ["./tg2sip-go"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  tg2sip:
+    build: .
+    image: tg2sip-go
+    volumes:
+      - ./settings.ini:/app/settings.ini:ro
+    ports:
+      - "5060:5060/udp"
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add Dockerfile that builds tg2sip-go with libtdjson and exposes SIP port
- include docker-compose.yml for containerized deployment

## Testing
- `go build` (fails: td/telegram/td_json_client.h: No such file or directory)
- `docker --version` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a2645a1004832694d8a70a67701945