### PR TITLE
Use prebuilt tdlib base image for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,40 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.22-bookworm AS build
+FROM ghcr.io/zelenin/tdlib-docker:b498497-alpine AS tdlib
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libtdjson-dev && \
-    rm -rf /var/lib/apt/lists/*
+FROM golang:1.24.1-alpine3.21 AS build
+ENV LANG=en_US.UTF-8
+ENV TZ=UTC
+RUN set -eux && \
+    apk update && \
+    apk upgrade && \
+    apk add \
+        bash \
+        build-base \
+        ca-certificates \
+        curl \
+        git \
+        linux-headers \
+        openssl-dev \
+        zlib-dev
 
 WORKDIR /app
-
+COPY --from=tdlib /usr/local/include/td /usr/local/include/td/
+COPY --from=tdlib /usr/local/lib/libtd* /usr/local/lib/
 COPY go go
-
 RUN cd go && go build -o tg2sip-go
 
-FROM debian:bookworm-slim
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libtdjson && \
-    rm -rf /var/lib/apt/lists/*
-
+FROM alpine:3.21.3
+ENV LANG=en_US.UTF-8
+ENV TZ=UTC
+RUN apk upgrade --no-cache && \
+    apk add --no-cache \
+        ca-certificates \
+        libstdc++
 WORKDIR /app
-
 COPY --from=build /app/go/tg2sip-go /app/go/tg2sip-go
 COPY settings.ini /app/settings.ini
-
 WORKDIR /app/go
-
 EXPOSE 5060/udp
-
 CMD ["./tg2sip-go"]
 


### PR DESCRIPTION
## Summary
- build container from ghcr.io/zelenin/tdlib-docker to avoid missing libtdjson

## Testing
- `docker build .` *(fails: command not found: docker)*
- `go build -o tg2sip` *(fails: td/telegram/td_json_client.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a2664270f08326a2e8310bb0e0c83f