### PR TITLE
chore: use Go 1.24.3 in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM ghcr.io/zelenin/tdlib-docker:b498497-alpine AS tdlib
 
-FROM golang:1.24.1-alpine3.21 AS build
+FROM golang:1.24.3-alpine3.21 AS build
 ENV LANG=en_US.UTF-8
 ENV TZ=UTC
 RUN set -eux && \


### PR DESCRIPTION
## Summary
- update Docker build stage to use Go 1.24.3

## Testing
- `docker build --target build .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*
- `cd go && go build -o tg2sip-go` *(fails: fatal error: td/telegram/td_json_client.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a26800efe883268afbcda848be440c