### PR TITLE
Enhance gateway with Telegram call handling and SIP header mapping

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -132,7 +132,7 @@ func main() {
 	if err := startTG(cfg); err != nil {
 		coreLog.Fatalf("failed to start Telegram client: %v", err)
 	}
-	if err := startGateway(); err != nil {
+	if err := startGateway(cfg); err != nil {
 		coreLog.Fatalf("failed to start gateway: %v", err)
 	}
 

--- a/go/sipclient.go
+++ b/go/sipclient.go
@@ -17,8 +17,8 @@ func NewSIPClient(srv gosip.Server) *SIPClient {
 }
 
 // Dial starts a new outbound call.
-func (c *SIPClient) Dial(ctx context.Context, from, to string) error {
-	coreLog.Infof("SIP Dial from %s to %s", from, to)
+func (c *SIPClient) Dial(ctx context.Context, from, to string, headers map[string]string) error {
+	coreLog.Infof("SIP Dial from %s to %s headers=%v", from, to, headers)
 	return nil
 }
 

--- a/go/telegram_calls.go
+++ b/go/telegram_calls.go
@@ -1,0 +1,17 @@
+package main
+
+import client "github.com/zelenin/go-tdlib/client"
+
+// createTelegramCall starts a Telegram call to the specified user.
+func createTelegramCall(cl *client.Client, userID int64) error {
+	protocol := &client.CallProtocol{UdpP2p: true, UdpReflector: true, MinLayer: 65, MaxLayer: 92}
+	_, err := cl.CreateCall(&client.CreateCallRequest{UserId: userID, Protocol: protocol})
+	return err
+}
+
+// acceptTelegramCall accepts an incoming Telegram call.
+func acceptTelegramCall(cl *client.Client, callID int64) error {
+	protocol := &client.CallProtocol{UdpP2p: true, UdpReflector: true, MinLayer: 65, MaxLayer: 92}
+	_, err := cl.AcceptCall(&client.AcceptCallRequest{CallId: callID, Protocol: protocol})
+	return err
+}


### PR DESCRIPTION
## Summary
- Parse SIP extensions and custom headers to resolve Telegram users
- Use helper module to create/accept Telegram calls and propagate user info
- Attach Telegram user details as SIP headers when bridging TG calls to SIP

## Testing
- `go build ./...` (fails: td/telegram/td_json_client.h: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68a269abdfac8326b11d7145e928cdf6