### PR TITLE
Fix build errors with updated Go libraries

### DIFF
--- a/go/gateway.go
+++ b/go/gateway.go
@@ -468,10 +468,7 @@ func (g *Gateway) handleInfo(req sip.Request, tx sip.ServerTransaction) {
 	if cid != nil {
 		callID = cid.String()
 	}
-	body := ""
-	if b := req.Body(); b != nil {
-		body = b.String()
-	}
+	body := req.Body()
 	coreLog.Infof("received SIP INFO: %s", callID)
 	g.events <- MediaEvent{CallID: callID, Body: body}
 	g.internalEvents <- internalEvent{ctxID: callID, typ: evWaitDTMF}

--- a/go/main.go
+++ b/go/main.go
@@ -59,20 +59,19 @@ func startTG(ctx context.Context, cfg *Settings) error {
 	}
 
 	params := &client.SetTdlibParametersRequest{
-		UseTestDc:              false,
-		DatabaseDirectory:      filepath.Join(dataDir, "database"),
-		FilesDirectory:         filepath.Join(dataDir, "files"),
-		UseFileDatabase:        true,
-		UseChatInfoDatabase:    true,
-		UseMessageDatabase:     true,
-		UseSecretChats:         false,
-		ApiId:                  int32(apiID),
-		ApiHash:                apiHash,
-		SystemLanguageCode:     cfg.SystemLanguageCode(),
-		DeviceModel:            cfg.DeviceModel(),
-		SystemVersion:          cfg.SystemVersion(),
-		ApplicationVersion:     cfg.ApplicationVersion(),
-		EnableStorageOptimizer: true,
+		UseTestDc:           false,
+		DatabaseDirectory:   filepath.Join(dataDir, "database"),
+		FilesDirectory:      filepath.Join(dataDir, "files"),
+		UseFileDatabase:     true,
+		UseChatInfoDatabase: true,
+		UseMessageDatabase:  true,
+		UseSecretChats:      false,
+		ApiId:               int32(apiID),
+		ApiHash:             apiHash,
+		SystemLanguageCode:  cfg.SystemLanguageCode(),
+		DeviceModel:         cfg.DeviceModel(),
+		SystemVersion:       cfg.SystemVersion(),
+		ApplicationVersion:  cfg.ApplicationVersion(),
 	}
 
 	authorizer := client.ClientAuthorizer(params)
@@ -106,7 +105,7 @@ func startTG(ctx context.Context, cfg *Settings) error {
 		}
 	}
 
-	me, err := tgClient.GetMe(context.Background())
+	me, err := tgClient.GetMe()
 	if err != nil {
 		return fmt.Errorf("get me: %w", err)
 	}

--- a/go/telegram_calls.go
+++ b/go/telegram_calls.go
@@ -25,7 +25,7 @@ func createTelegramCall(cl *client.Client, userID int64) error {
 // acceptTelegramCall accepts an incoming Telegram call.
 func acceptTelegramCall(cl *client.Client, callID int64) error {
 	protocol := &client.CallProtocol{UdpP2p: true, UdpReflector: true, MinLayer: 65, MaxLayer: 92}
-	if _, err := cl.AcceptCall(&client.AcceptCallRequest{CallId: callID, Protocol: protocol}); err != nil {
+	if _, err := cl.AcceptCall(&client.AcceptCallRequest{CallId: int32(callID), Protocol: protocol}); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary
- Remove obsolete TDLib parameter and update API call signatures
- Simplify SIP INFO handler body retrieval
- Cast call identifiers to expected types in Telegram call helpers

## Testing
- `cd go && go build -o tg2sip-go` *(fails: td/telegram/td_json_client.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a27e5288e48326b76c66c34e44031f