### PR TITLE
Enable interactive login for Docker deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,5 @@ services:
     ports:
       - "5060:5060/udp"
     restart: unless-stopped
+    stdin_open: true    # keep STDIN open for interactive login
+    tty: true           # allocate a pseudo-TTY for login prompts


### PR DESCRIPTION
## Summary
- allow entering Telegram phone number when running via docker-compose by keeping STDIN open and allocating a TTY

## Testing
- `go build ./...` *(fails: td/telegram/td_json_client.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ff3bf3e883268c906049e8b6b720