### PR TITLE
Enable interactive login for Docker deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Your SIP PBX should be comaptible with `L16@48000` or `OPUS@48000` voice codec.
    *  Download universal AppImage package.  
       More information of what is AppImage can be found here https://appimage.org/
       
-2. Obtain `api_id` and `api_hash` tokens from [this](https://my.telegram.org) page and put them in `settings.ini` file.
+2. Obtain `api_id` and `api_hash` tokens from [this](https://my.telegram.org) page and put them in `settings.ini` file. Optionally set `phone_number` to prefill the login prompt.
 3. Login into telegram with `gen_db` app
 4. Set SIP server settings in `settings.ini`
 5. Run `tg2sip`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,5 @@ services:
     ports:
       - "5060:5060/udp"
     restart: unless-stopped
+    stdin_open: true    # keep STDIN open for interactive login
+    tty: true           # allocate a pseudo-TTY for login prompts

--- a/settings.ini
+++ b/settings.ini
@@ -42,6 +42,7 @@
 api_id=                         ; Application identifier for Telegram API access
 api_hash=                       ; Application identifier hash for Telegram API access
                                 ; which can be obtained at https://my.telegram.org.
+;phone_number=                  ; Phone number used for Telegram authentication
 
 ;system_language_code=en-US     ; IETF language tag of the user's operating system language
 

--- a/settings.ini.example
+++ b/settings.ini.example
@@ -42,6 +42,7 @@
 api_id=                         ; Application identifier for Telegram API access
 api_hash=                       ; Application identifier hash for Telegram API access
                                 ; which can be obtained at https://my.telegram.org.
+;phone_number=                  ; Phone number used for Telegram authentication
 
 ;system_language_code=en-US     ; IETF language tag of the user's operating system language
 

--- a/tg2sip/gen_db.cpp
+++ b/tg2sip/gen_db.cpp
@@ -180,9 +180,11 @@ private:
                             std::cout << "Confirm this login link on another device: " << state.link_ << std::endl;
                         },
                         [this](td_api::authorizationStateWaitPhoneNumber &) {
-                            std::cout << "Enter phone number: " << std::flush;
-                            std::string phone_number;
-                            std::cin >> phone_number;
+                            std::string phone_number = settings.phone_number();
+                            if (phone_number.empty()) {
+                                std::cout << "Enter phone number: " << std::flush;
+                                std::cin >> phone_number;
+                            }
                             send_query(td_api::make_object<td_api::setAuthenticationPhoneNumber>(phone_number, nullptr),
                                        create_authentication_query_handler());
                         },

--- a/tg2sip/settings.cpp
+++ b/tg2sip/settings.cpp
@@ -48,6 +48,7 @@ Settings::Settings(INIReader &reader) {
     //telegram
     api_id_ = static_cast<int>(reader.GetInteger("telegram", "api_id", 0));
     api_hash_ = reader.Get("telegram", "api_hash", "");
+    phone_number_ = reader.Get("telegram", "phone_number", "");
     db_folder_ = reader.Get("telegram", "database_folder", "");
     system_language_code_ = reader.Get("telegram", "database_folder", "en-US");
     device_model_ = reader.Get("telegram", "device_model", "PC");

--- a/tg2sip/settings.h
+++ b/tg2sip/settings.h
@@ -43,6 +43,7 @@ private:
 
     int api_id_;
     std::string api_hash_;
+    std::string phone_number_;
     std::string db_folder_;
     std::string system_language_code_;
     std::string device_model_;
@@ -113,6 +114,8 @@ public:
     int api_id() const { return api_id_; };
 
     std::string api_hash() const { return api_hash_; };
+
+    std::string phone_number() const { return phone_number_; };
 
     std::string db_folder() const { return db_folder_; };
 


### PR DESCRIPTION
## Summary
- keep STDIN open and allocate a TTY for containerized runs so Telegram prompts are visible
- allow specifying `phone_number` in settings.ini to skip the phone prompt during authentication

## Testing
- `go build -v ./...` *(fails: td/telegram/td_json_client.h: No such file or directory)*
- `cmake -S . -B build` *(fails: The following required packages were not found: opus)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ff3bf3e883268c906049e8b6b720