### PR TITLE
Fix SIP status constant reference

### DIFF
--- a/go/sipclient.go
+++ b/go/sipclient.go
@@ -167,7 +167,7 @@ func (c *SIPClient) Answer(ctx context.Context, callID string) error {
 		return fmt.Errorf("call %s not found", callID)
 	}
 
-	res := sip.NewResponseFromRequest("", sess.inviteReq, sip.StatusOK, "OK", "")
+	res := sip.NewResponseFromRequest("", sess.inviteReq, statusOK, "OK", "")
 	tag := util.RandString(8)
 	if toHdr, ok := res.To(); ok {
 		toHdr.Params = toHdr.Params.Add("tag", sip.String{Str: tag})


### PR DESCRIPTION
## Summary
- use existing `statusOK` constant instead of undefined `sip.StatusOK`

## Testing
- `go vet ./...` *(fails: td/telegram/td_json_client.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a50da7b90883268c06333f6e3b580f