### PR TITLE
Auto-detect SIP source address

### DIFF
--- a/go/iputil.go
+++ b/go/iputil.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"net"
+)
+
+// detectHostIP returns the first non-loopback IPv4 address of the host.
+func detectHostIP() (string, error) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return "", err
+	}
+	for _, addr := range addrs {
+		ipnet, ok := addr.(*net.IPNet)
+		if !ok || ipnet.IP.IsLoopback() {
+			continue
+		}
+		if ip4 := ipnet.IP.To4(); ip4 != nil {
+			return ip4.String(), nil
+		}
+	}
+	return "", fmt.Errorf("no non-loopback IPv4 address found")
+}

--- a/go/main.go
+++ b/go/main.go
@@ -23,6 +23,14 @@ func startSIP(ctx context.Context, cfg *Settings) error {
 	port := cfg.SIPPort()
 	portRange := cfg.SIPPortRange()
 	host := cfg.PublicAddress()
+	if host == "" {
+		if ip, err := detectHostIP(); err != nil {
+			coreLog.Warnf("auto detect address: %v", err)
+		} else {
+			host = ip
+			coreLog.Infof("auto detected address %s", host)
+		}
+	}
 
 	logger := gosiplog.NewLogrusLogger(pjsipLog, "SIP", nil)
 

--- a/settings.ini.example
+++ b/settings.ini.example
@@ -18,7 +18,8 @@
                         ; 1-errors  3-info      5-verbose debug
 
 [sip]
-;public_address=        ; Address to advertise as the address UDP transport.
+;public_address=        ; Address to advertise as the address UDP transport. If not set,
+                        ; the first non-loopback IPv4 address will be used.
 
 ;stun_server=
 


### PR DESCRIPTION
## Summary
- detect host IP if SIP `public_address` is unset
- log detected address during SIP start
- document default public address behaviour

## Testing
- `go test ./...` *(fails: td/telegram/td_json_client.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5101f9d68832698ea3c5344b39a98