### PR TITLE
Ignore loopback addresses in host IP detection

### DIFF
--- a/go/iputil.go
+++ b/go/iputil.go
@@ -13,10 +13,15 @@ func detectHostIP() (string, error) {
 	}
 	for _, addr := range addrs {
 		ipnet, ok := addr.(*net.IPNet)
-		if !ok || ipnet.IP.IsLoopback() {
+		if !ok {
 			continue
 		}
 		if ip4 := ipnet.IP.To4(); ip4 != nil {
+			// Ensure we never return an address from the 127.0.0.0/8
+			// loopback range.
+			if ip4.IsLoopback() || ip4[0] == 127 {
+				continue
+			}
 			return ip4.String(), nil
 		}
 	}


### PR DESCRIPTION
## Summary
- ignore 127.0.0.0/8 addresses when detecting host IPs

## Testing
- `go vet ./...` *(fails: td/telegram/td_json_client.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c1b81b6c832697b8c43e93f5591c