### PR TITLE
Fix host IP detection for SIP server

### DIFF
--- a/go/iputil.go
+++ b/go/iputil.go
@@ -5,21 +5,46 @@ import (
 	"net"
 )
 
-// detectHostIP returns the first non-loopback IPv4 address of the host.
+// detectHostIP returns the first global unicast IPv4 address of the host.
+//
+// The previous implementation relied on net.InterfaceAddrs which could return
+// addresses from down or loopback interfaces and even the unspecified
+// "0.0.0.0" address.  That resulted in selecting an unusable source address
+// such as 127.0.0.1 when sending SIP messages over UDP, causing failures like
+// "sendto: invalid argument".  We now iterate over the network interfaces,
+// selecting the first address that is up, not loopback and globally routable.
 func detectHostIP() (string, error) {
-	addrs, err := net.InterfaceAddrs()
+	ifaces, err := net.Interfaces()
 	if err != nil {
 		return "", err
 	}
-	for _, addr := range addrs {
-		ipnet, ok := addr.(*net.IPNet)
-		if !ok {
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 {
 			continue
 		}
-		if ip4 := ipnet.IP.To4(); ip4 != nil {
-			// Ensure we never return an address from the 127.0.0.0/8
-			// loopback range.
-			if ip4.IsLoopback() || ip4[0] == 127 {
+		if iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil {
+				continue
+			}
+			ip4 := ip.To4()
+			if ip4 == nil {
+				continue
+			}
+			if !ip4.IsGlobalUnicast() {
 				continue
 			}
 			return ip4.String(), nil


### PR DESCRIPTION
## Summary
- avoid selecting loopback/unspecified addresses when auto-detecting host IP

## Testing
- `go vet ./...` *(fails: td/telegram/td_json_client.h: No such file or directory)*
- `go test ./...` *(fails: td/telegram/td_json_client.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c40ebb0483268a216f178f2212d4