### PR TITLE
fix: bind SIP server to detected host

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -38,7 +38,13 @@ func startSIP(ctx context.Context, cfg *Settings) error {
 
 	var listenErr error
 	for i := 0; i <= portRange; i++ {
+		// Explicitly include host in listen address to avoid binding to
+		// the default loopback address when a public address is
+		// detected. When host is empty, fall back to all interfaces.
 		addr := fmt.Sprintf(":%d", port+i)
+		if host != "" {
+			addr = fmt.Sprintf("%s:%d", host, port+i)
+		}
 		listenErr = sipServer.Listen("udp", addr)
 		if listenErr == nil {
 			coreLog.Infof("SIP server listening on %s/udp", addr)


### PR DESCRIPTION
## Summary
- bind SIP server listener to public/detected address instead of loopback

## Testing
- `go test ./...` *(fails: td/telegram/td_json_client.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c76274988326bf55206174af15e6