### PR TITLE
fix: handle nil SIP address params when tagging

### DIFF
--- a/go/sipclient.go
+++ b/go/sipclient.go
@@ -55,6 +55,9 @@ func (c *SIPClient) TrackInvite(req sip.Request, tx sip.ServerTransaction) {
 	}
 	if fromHdr != nil && fromHdr.Params != nil {
 		if tag, ok := fromHdr.Params.Get("tag"); ok {
+			if sess.remoteAddr.Params == nil {
+				sess.remoteAddr.Params = sip.NewParams()
+			}
 			sess.remoteAddr.Params = sess.remoteAddr.Params.Add("tag", tag)
 		}
 	}
@@ -134,6 +137,9 @@ func (c *SIPClient) Dial(ctx context.Context, from, to string, headers map[strin
 						if tag, ok := toHdr.Params.Get("tag"); ok {
 							c.mu.Lock()
 							if sess, ok := c.calls[callID]; ok {
+								if sess.remoteAddr.Params == nil {
+									sess.remoteAddr.Params = sip.NewParams()
+								}
 								sess.remoteAddr.Params = sess.remoteAddr.Params.Add("tag", tag)
 							}
 							c.mu.Unlock()


### PR DESCRIPTION
## Summary
- guard against nil Params when adding tag to remote address

## Testing
- `go build ./...` *(fails: td/telegram/td_json_client.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ca2a270c8326a16830776b6461e4